### PR TITLE
upgrade composer 'nouislider' 10.1.0 => 14.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "yiisoft/yii2": "*",
-        "npm-asset/nouislider": "10.1.0"
+        "npm-asset/nouislider": "14.0.*"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
I've checked noUiSlider changelog, and looks like API didn't changed - so we can upgrade it.

Btw, thx for your `ruskid/yii2-nouislider` ! =)